### PR TITLE
Add grid snapping to road drawing

### DIFF
--- a/src/RoadMapperApp.js
+++ b/src/RoadMapperApp.js
@@ -59,7 +59,8 @@ export class RoadMapperApp {
       
       // Initialize UI components
       this.toolbar = new Toolbar('toolbar-container', this.toolManager);
-      this.statusBar = new StatusBar('status-bar-container', this.viewport, this.grid);
+      this.statusBar = new StatusBar(this.viewport, this.toolManager, this.grid);
+      this.statusBar.mount('status-bar-container');
       
       // Initialize properties panels
       this.intersectionPropertiesPanel = new IntersectionPropertiesPanel(this.elementManager);

--- a/src/app.js
+++ b/src/app.js
@@ -66,7 +66,7 @@ class RoadMapperApp {
       this.toolbar = new Toolbar('toolbar-container', this.toolManager);
       // Toolbar mounted
 
-      this.statusBar = new StatusBar(this.viewport, this.toolManager);
+      this.statusBar = new StatusBar(this.viewport, this.toolManager, this.grid);
       this.statusBar.mount('status-bar-container');
       // StatusBar mounted
 

--- a/src/components/StatusBar.js
+++ b/src/components/StatusBar.js
@@ -2,9 +2,10 @@ import { PIXELS_PER_METER, ZOOM_LEVELS } from '../core/constants.js';
 import { RoadRenderer } from '../modules/rendering/RoadRenderer.js';
 
 export class StatusBar {
-  constructor(viewport, toolManager) {
+  constructor(viewport, toolManager, grid = null) {
     this.viewport = viewport;
     this.toolManager = toolManager;
+    this.grid = grid;
     this.container = null;
     this.elements = {};
   }
@@ -62,8 +63,12 @@ export class StatusBar {
 
   bindEvents() {
     this.toolManager.on('cursorMove', (worldPos) => {
-      const x = Math.round(worldPos.x / PIXELS_PER_METER);
-      const y = Math.round(worldPos.y / PIXELS_PER_METER);
+      let snapped = worldPos;
+      if (this.grid) {
+        snapped = this.grid.snap(worldPos.x, worldPos.y, this.grid.smallGrid);
+      }
+      const x = Math.round(snapped.x / PIXELS_PER_METER);
+      const y = Math.round(snapped.y / PIXELS_PER_METER);
       this.elements.cursorPosition.textContent = `${x}m, ${y}m`;
     });
     

--- a/src/modules/grid/Grid.js
+++ b/src/modules/grid/Grid.js
@@ -3,18 +3,21 @@ import { GRID_SIZES, PIXELS_PER_METER } from '../../core/constants.js';
 export class Grid {
   constructor(gridSize = GRID_SIZES.MEDIUM) {
     this.gridSize = gridSize;
+    this.smallGrid = GRID_SIZES.FINE;
     this.snapEnabled = true;
     this.visible = true;
   }
 
-  snap(x, y) {
+  snap(x, y, interval = this.gridSize) {
     if (!this.snapEnabled) {
       return { x, y };
     }
-    
+
+    const size = interval || this.gridSize;
+
     return {
-      x: Math.round(x / this.gridSize) * this.gridSize,
-      y: Math.round(y / this.gridSize) * this.gridSize
+      x: Math.round(x / size) * size,
+      y: Math.round(y / size) * size
     };
   }
 

--- a/src/modules/tools/RoadTool.js
+++ b/src/modules/tools/RoadTool.js
@@ -47,7 +47,7 @@ export class RoadTool extends BaseTool {
   }
 
   onMouseDown(event, worldPos) {
-    const snappedPos = this.grid.snap(worldPos.x, worldPos.y);
+    const snappedPos = this.grid.snap(worldPos.x, worldPos.y, this.grid.smallGrid);
     
     if (!this.isDrawing) {
       this.startRoad(snappedPos.x, snappedPos.y);
@@ -58,7 +58,7 @@ export class RoadTool extends BaseTool {
 
   onMouseMove(event, worldPos) {
     if (this.isDrawing) {
-      this.previewPoint = this.grid.snap(worldPos.x, worldPos.y);
+      this.previewPoint = this.grid.snap(worldPos.x, worldPos.y, this.grid.smallGrid);
       
       // Check for potential T-intersection
       // For segment drawing, we need to pass the start point of the current segment


### PR DESCRIPTION
## Summary
- expose `smallGrid` and snap interval support in `Grid`
- ensure `RoadTool` uses the fine grid when snapping
- show snapped coordinates in `StatusBar`
- pass grid to `StatusBar` during app initialization

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_686c8a52b0b8832dae5db070b45c5cea