### PR TITLE
Add zone and intersection drawing tools

### DIFF
--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -36,6 +36,11 @@ export class Toolbar {
             <path d="M12 2v4m0 12v4M2 12h4m12 0h4"/>
           </svg>
         </button>
+        <button data-tool="${TOOLS.ZONE}" class="tool-button" data-tooltip="Zone Tool (Z)">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="4" y="4" width="16" height="16"/>
+          </svg>
+        </button>
         <button data-tool="${TOOLS.DELETE}" class="tool-button" data-tooltip="Delete Tool (D)">
           <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <path d="M3 6h18"/>
@@ -114,6 +119,9 @@ export class Toolbar {
           break;
         case 'i':
           this.selectTool(TOOLS.INTERSECTION);
+          break;
+        case 'z':
+          this.selectTool(TOOLS.ZONE);
           break;
         case 'd':
           this.selectTool(TOOLS.DELETE);

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -7,6 +7,7 @@ export const TOOLS = {
   SELECT: 'select',
   ROAD: 'road',
   INTERSECTION: 'intersection',
+  ZONE: 'zone',
   DELETE: 'delete',
   PAN: 'pan',
   BUILDING: 'building'

--- a/src/modules/tools/ToolManager.js
+++ b/src/modules/tools/ToolManager.js
@@ -2,7 +2,8 @@ import { EventEmitter } from '../../core/EventEmitter.js';
 import { TOOLS } from '../../core/constants.js';
 import { SelectTool } from './SelectTool.js';
 import { RoadTool } from './RoadTool.js';
-import { IntersectionTool } from './IntersectionTool.js';
+import { IntersectionTool } from '../../tools/intersectionTool.js';
+import { ZoneTool } from '../../tools/zoneTool.js';
 import { DeleteTool } from './DeleteTool.js';
 import { PanTool } from './PanTool.js';
 import { BuildingTool } from './BuildingTool.js';
@@ -19,6 +20,7 @@ export class ToolManager extends EventEmitter {
       [TOOLS.SELECT]: new SelectTool(this),
       [TOOLS.ROAD]: new RoadTool(this),
       [TOOLS.INTERSECTION]: new IntersectionTool(this),
+      [TOOLS.ZONE]: new ZoneTool(this),
       [TOOLS.DELETE]: new DeleteTool(this),
       [TOOLS.PAN]: new PanTool(this),
       [TOOLS.BUILDING]: new BuildingTool(this)
@@ -83,8 +85,9 @@ export class ToolManager extends EventEmitter {
     // Update class on SVG container for tool-specific styling
     if (this.canvas && this.canvas.tagName === 'svg') {
       // Remove all tool classes
-      this.canvas.classList.remove('select-tool-active', 'road-tool-active', 
-        'building-tool-active', 'intersection-tool-active', 'delete-tool-active', 'pan-tool-active');
+      this.canvas.classList.remove('select-tool-active', 'road-tool-active',
+        'building-tool-active', 'intersection-tool-active', 'zone-tool-active',
+        'delete-tool-active', 'pan-tool-active');
       
       // Add current tool class
       const toolClass = toolName.toLowerCase() + '-tool-active';

--- a/src/state.js
+++ b/src/state.js
@@ -1,0 +1,7 @@
+export const state = {
+  elements: {
+    roads: [],
+    intersections: [],
+    zones: []
+  }
+};

--- a/src/tools/intersectionTool.js
+++ b/src/tools/intersectionTool.js
@@ -1,0 +1,20 @@
+import { BaseTool } from '../modules/tools/BaseTool.js';
+import { state } from '../state.js';
+
+export class IntersectionTool extends BaseTool {
+  onMouseDown(event, worldPos) {
+    if (event.button !== 0) return;
+    const snapped = this.grid.snap(worldPos.x, worldPos.y, this.grid.smallGrid);
+    const intersection = {
+      id: `intersection_${Date.now()}`,
+      x: snapped.x,
+      y: snapped.y
+    };
+    state.elements.intersections.push(intersection);
+    this.toolManager.emit('redraw');
+  }
+
+  getCursor() {
+    return 'crosshair';
+  }
+}

--- a/src/tools/zoneTool.js
+++ b/src/tools/zoneTool.js
@@ -1,0 +1,67 @@
+import { BaseTool } from '../modules/tools/BaseTool.js';
+import { state } from '../state.js';
+
+export class ZoneTool extends BaseTool {
+  constructor(toolManager) {
+    super(toolManager);
+    this.isDrawing = false;
+    this.currentZone = null;
+    this.previewPoint = null;
+  }
+
+  onMouseDown(event, worldPos) {
+    if (event.button !== 0) return;
+    const snapped = this.grid.snap(worldPos.x, worldPos.y, this.grid.smallGrid);
+    if (!this.isDrawing) {
+      this.currentZone = { id: `zone_${Date.now()}`, points: [snapped] };
+      this.isDrawing = true;
+    } else {
+      this.currentZone.points.push(snapped);
+    }
+  }
+
+  onMouseMove(event, worldPos) {
+    if (!this.isDrawing) return;
+    this.previewPoint = this.grid.snap(worldPos.x, worldPos.y, this.grid.smallGrid);
+    this.toolManager.emit('redraw');
+  }
+
+  onMouseUp(event, worldPos) {
+    if (event.detail === 2 && this.isDrawing) {
+      this.finishZone();
+    }
+  }
+
+  finishZone() {
+    if (this.currentZone && this.currentZone.points.length > 2) {
+      state.elements.zones.push(this.currentZone);
+    }
+    this.currentZone = null;
+    this.isDrawing = false;
+    this.previewPoint = null;
+    this.toolManager.emit('redraw');
+  }
+
+  getCursor() {
+    return 'crosshair';
+  }
+
+  renderSVG(svgManager) {
+    if (!this.currentZone) return;
+    const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    const pts = this.currentZone.points;
+    if (pts.length === 0) return;
+    let d = `M ${pts[0].x} ${pts[0].y}`;
+    for (let i = 1; i < pts.length; i++) {
+      d += ` L ${pts[i].x} ${pts[i].y}`;
+    }
+    if (this.previewPoint) {
+      d += ` L ${this.previewPoint.x} ${this.previewPoint.y}`;
+    }
+    path.setAttribute('d', d);
+    path.setAttribute('fill', 'rgba(0, 128, 255, 0.3)');
+    path.setAttribute('stroke', '#0080ff');
+    path.setAttribute('stroke-dasharray', '4 4');
+    svgManager.addToLayer('overlay', path);
+  }
+}


### PR DESCRIPTION
## Summary
- implement simple global state container
- add ZoneTool and simple IntersectionTool modules under `src/tools`
- register new tools in `ToolManager`
- expose `ZONE` tool constant
- update Toolbar UI and shortcuts to use new tools

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build:dev` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c9622ad70832d9f29a217b32c31d8